### PR TITLE
Alternative Charter Proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
 # Inclusivity Working Group
 
-This working group is still in the early stages of getting up and running. Check back soon for more info!
+## Proposed Charter
+
+(this charter has not yet been ratified by the TSC and has no official standing)
+
+### Statement of Purpose
+
+The Inclusivity Working Group seeks to increase inclusivity and diversity within the Node.js project by working with the collaborators and community at large to ensure a safe and friendly environment for all individuals who wish to contribute.
+
+### Responsibilities
+
+* Foster an environment that ensures that any and all individuals feel equally welcomed and empowered to openly participate in all aspects of the Node.js project.
+* Leverage only open and inclusive channels of communication to discuss inclusivity and diversity matters that impact all participants in the Node.js project.
+* Proactively seek and propose -- using Node.js' existing governance and development policies -- concrete steps and best practices that all collaborators can follow to improve inclusivity and diversity.
+* Serve as a resource for all collaborators to help identify specific barriers to inclusivity and diversity and to work collaboratively with all members of the project to resolve those barriers using Node.js' established open governance model.
+
+### Membership
+
+Membership and participation with the Inclusivity Working Group is open to any member of the Node.js Github Organization. 
+
+### Code of Conduct
+
+The existing Node.js [Code of Conduct](https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md) applies to all aspects of this Working Group's operation.
+
+Because of the potentially sensitive and personal nature of diversity issues, any individual participating in Inclusivity Working Group matters is expected to respect and protect the privacy and dignity of all other participants.
+
+While it is not expected that every participant in Working Group discussions will agree on every matter, individuals who habitually harass, demean, insult or otherwise disrespect others participating in Inclusivity Working Group matters will be asked to recuse themselves of any further participation. 
+
+Obvious and gross violations of the Code of Conduct will result in mandatory exclusion from all Inclusivity Working Group discussions.
+
+### Conflict Resolution
+
+When disagreements arise that do not appear to be resolvable through normal discourse, the TSC will serve as the final arbiter following the TSC's [Consensus Seeking decision making model](https://github.com/joyent/nodejs-advisory-board/blob/master/governance-proposal/TSC-Charter-Draft.md#section-8-voting). Such issues should be tagged using the `tsc-agenda` label to escalate the issue for TSC review.


### PR DESCRIPTION
An alternative proposed charter for the Inclusivity Working Group. 
(Would replace: https://github.com/nodejs/inclusivity/pull/21 and https://github.com/nodejs/inclusivity/pull/22.)
